### PR TITLE
Fix camera viewport scaling so the miner stays on screen

### DIFF
--- a/src/game/renderer.js
+++ b/src/game/renderer.js
@@ -3,10 +3,11 @@ import { getLayer, getPaintMask } from './tiles.js';
 
 export function render(ctx, cam, level, player, enemies, rules) {
   const scale = CONFIG.WORLD_SCALE;
-  ctx.setTransform(scale, 0, 0, scale, -cam.x*scale, -cam.y*scale);
+  ctx.imageSmoothingEnabled = false;
+  ctx.setTransform(scale, 0, 0, scale, -cam.x * scale, -cam.y * scale);
   // clear
   ctx.fillStyle = '#0b0f14';
-  ctx.fillRect(cam.x, cam.y, cam.vw/scale, cam.vh/scale);
+  ctx.fillRect(cam.x, cam.y, cam.vw, cam.vh);
 
   drawTiles(ctx, level);
   drawPaint(ctx, level);

--- a/src/main.js
+++ b/src/main.js
@@ -27,7 +27,10 @@ async function boot() {
   const start = level.entities.find(e => e.type === 'playerStart') || {x: 2 * CONFIG.TILE, y: 2 * CONFIG.TILE};
   player = new Player(start.x, start.y);
   enemies = level.entities.filter(e => e.type === 'enemy').map(e => new Enemy(e.x, e.y, e.patrolMinX, e.patrolMaxX));
-  camera = new Camera(0, 0, canvas.width, canvas.height, level.width * CONFIG.TILE, level.height * CONFIG.TILE);
+  const viewWidth = canvas.width / CONFIG.WORLD_SCALE;
+  const viewHeight = canvas.height / CONFIG.WORLD_SCALE;
+  camera = new Camera(0, 0, viewWidth, viewHeight, level.width * CONFIG.TILE, level.height * CONFIG.TILE);
+  camera.follow(player.x, player.y);
 
   const stats = getPaintStats(level);
   ui.paintTotal.textContent = stats.total;


### PR DESCRIPTION
## Summary
- size the camera viewport using world units so scaling no longer hides the miner
- center the camera on the spawn point during boot
- clear the render buffer in world space and disable smoothing for crisp pixels

## Testing
- not run (web project)


------
https://chatgpt.com/codex/tasks/task_e_68de79aa76548327be133d7b8c7c7d07